### PR TITLE
Eliminación de Ventas

### DIFF
--- a/nostro/ventas/controller_venta.py
+++ b/nostro/ventas/controller_venta.py
@@ -17,13 +17,16 @@ def Productos():
     """Retorna todos los Productos de la base de datos"""
     return Producto.all()
 
+
 def getPedidos():
     """Retorna todos los pedidos"""
     return Pedido.all()
 
+
 def getVentas():
     """Retorna todos los pedidos"""
     return Venta.all()
+
 
 def getPagos():
     """Retorna todos los pagos"""
@@ -65,7 +68,7 @@ def getProductoId(id_producto):
     return Producto.getProductoId(producto)
 
 
-def addDataPedido(mesa,en_curso=1):
+def addDataPedido(mesa, en_curso=1):
     """Agrega un pedido a la base de datos y retorna el id"""
     try:
         pedidos = getPedidos()[-1].id_pedido + 1
@@ -75,15 +78,18 @@ def addDataPedido(mesa,en_curso=1):
     Pedido.addDataPedido(pedido)
     return pedidos
 
+
 def finalizarPedido(id_pedido):
     pedido = Pedido()
     pedido.id_pedido = id_pedido
     Pedido.finalizarPedido(pedido)
 
+
 def getPedido(id_pedido):
     pedido = Pedido()
     pedido.id_pedido = id_pedido
     return Pedido.getPedido(pedido)
+
 
 def deletePedido(id_pedido):
     producto_pedido = VentaProducto()
@@ -93,10 +99,26 @@ def deletePedido(id_pedido):
     pedido.id_pedido = id_pedido
     Pedido.deletePedido(pedido)
 
+
+def delete_venta(id_venta, id_pedido):
+    """Elimina los registros relacionados a una venta"""
+    pago = Pago()
+    pago.id_venta = id_venta
+    pago.delete_pago()
+    venta = Venta(id_venta)
+    venta.delete_venta()
+    pedido = Pedido()
+    pedido.id_pedido = id_pedido
+    mensaje = Pedido.deletePedido(pedido)
+    if mensaje == "Error":
+        return mensaje
+
+
 def getPedidoActivoPorMesa(mesa):
     pedido = Pedido()
     pedido.mesa = mesa
     return Pedido.getPedidoActivoPorMesa(pedido)
+
 
 def addDataPago(pago_total, efectivo, tarjeta, propina, id_venta):
     """Agrega un pedido a la base de datos y retorna el id"""
@@ -127,6 +149,7 @@ def getProductosPedido(id_pedido):
     venta_producto = VentaProducto()
     venta_producto.id_pedido = id_pedido
     return VentaProducto.getProductosPedido(venta_producto)
+
 
 def getProductosPedidoRepetidosPorCantidad(id_pedido):
     productos_normal = getProductosPedido(id_pedido)
@@ -229,6 +252,7 @@ class TotalProductosModel(QtGui.QSortFilterProxyModel):
 
 # def set_headers(header)
 
+
 def editDataVenta(id_venta, fecha, total_pago, id_usuario):
     """ Modifica una venta finalizada """
     print("-----Edit Data Venta-------")
@@ -253,6 +277,7 @@ def getIdVenta(id_pedido):
     id_venta = Venta.get_id_venta(id_pedido)
     return id_venta
 
+
 class PushButtonMesa(QtGui.QPushButton):
     """
     Un QPushButton especializado que almacena el número de la mesa. Ademas posee un atributo para diferenciar las mesas unidas.
@@ -262,6 +287,7 @@ class PushButtonMesa(QtGui.QPushButton):
     habilitado = True
     unido = False
     unido_a = list()
+
     def __init__(self, text, ocupado=False, habilitado=True, parent=None):
         super(PushButtonMesa, self).__init__(parent)
         self.setText(text)
@@ -270,11 +296,11 @@ class PushButtonMesa(QtGui.QPushButton):
 
         self.setEnabled(habilitado)
         if(self.ocupado):
-            self.setProperty("ocupado",True)
+            self.setProperty("ocupado", True)
         else:
-            self.setProperty("ocupado",False)
+            self.setProperty("ocupado", False)
 
     def reset():
         self.habilitado = True
         self.setEnabled(True)
-        self.setText("Mesa "+str(mesa))
+        self.setText("Mesa " + str(mesa))

--- a/nostro/ventas/model_venta.py
+++ b/nostro/ventas/model_venta.py
@@ -43,6 +43,7 @@ def obtenerObjetoVentas(data):
                            row[3], row[4], row[5], row[6]))
     return lista
 
+
 def obtenerObjetoPagos(data):
     """
     Recibe como parametro la tupla recibida desde la BD y retorna una lista de objetos con todos los datos de los productos.
@@ -50,7 +51,7 @@ def obtenerObjetoPagos(data):
     lista = list()
     for i, row in enumerate(data):
         lista.append(Pago(row[0], row[1], row[2],
-                           row[3], row[4], row[5]))
+                          row[3], row[4], row[5]))
     return lista
 
 
@@ -89,19 +90,24 @@ class Pedido(object):
     def finalizarPedido(cls):
         conex = connect()
         conn = conex.cursor()
-        query = "UPDATE pedido SET en_curso = 0 WHERE idPedido = {0}".format(cls.id_pedido)
+        query = "UPDATE pedido SET en_curso = 0 WHERE idPedido = {0}".format(
+            cls.id_pedido)
         conn.execute(query)
         conex.commit()
         conn.close()
 
     def deletePedido(cls):
-        conex = connect()
-        conn = conex.cursor()
-        query = "DELETE FROM pedido WHERE idPedido = {0}".format(
-            cls.id_pedido)
-        conn.execute(query)
-        conex.commit()
-        conn.close()
+        try:
+            conex = connect()
+            conn = conex.cursor()
+            query = "DELETE FROM pedido WHERE idPedido = {0}".format(
+                cls.id_pedido)
+            conn.execute(query)
+            conex.commit()
+            conn.close()
+        except MySQLdb.Error as e:
+            conn.close()
+            return "Error"
 
     def getPedido(cls):
         query = "SELECT * FROM pedido WHERE idPedido = {0}".format(
@@ -205,7 +211,7 @@ class VentaProducto(object):
 
     def getProductosPedido(cls):
         """
-        Método utlizado para obtener los productos de un pedido espedifico.
+        Método utlizado para obtener los productos de un pedido especifico.
         """
         query = "SELECT * FROM venta_has_producto WHERE idPedido = {}".format(
             cls.id_pedido)
@@ -392,6 +398,15 @@ class Venta(object):
 
         conn.close()
 
+    def delete_venta(cls):
+        """Método que se encarga de eliminar un venta identificandola con su PK"""
+        conex = connect()
+        conn = conex.cursor()
+        query = "DELETE FROM venta WHERE idVenta = {}".format(cls.id_venta)
+        conn.execute(query)
+        conex.commit()
+        conn.close()
+
     @classmethod
     def getIdPedido(cls, id_venta):
         conex = connect()
@@ -488,6 +503,14 @@ class Pago(object):
         conex.commit()
         conn.close()
 
+    def delete_pago(cls):
+        conex = connect()
+        conn = conex.cursor()
+        query = "DELETE FROM pago WHERE idVenta = {}".format(cls.id_venta)
+        conn.execute(query)
+        conex.commit()
+        conn.close()
+
     @classmethod
     def all(cls):
         """
@@ -511,6 +534,3 @@ class Pago(object):
             print "Error al obtener los pagos:", e.args[0]
             conn.close()
             return None
-
-        
-

--- a/nostro/ventas/view_admin_venta.py
+++ b/nostro/ventas/view_admin_venta.py
@@ -46,6 +46,11 @@ class AdminVentas(QtGui.QWidget):
         self.reload_data_table()
 
     def action_btn_editar(self):
+        """
+        Luego de seleccionar una venta de la lista cambia a  la ventana
+        de venta con los datos de la venta seleccionada para poder realizar
+        cambios en ella.
+        """
         index = self.ui.tableView_ventas.currentIndex()
         if index.row() == -1:  # No se ha seleccionado venta
             msgBox = QtGui.QMessageBox()
@@ -80,10 +85,43 @@ class AdminVentas(QtGui.QWidget):
             self.mainwindow.stackedWidget.setCurrentIndex(4)
             self.mainwindow.stackedWidget.currentWidget().reload_data_table2()
             self.mainwindow.stackedWidget.currentWidget().load_productos_table2(id_pedido)
+            self.set_source_model(self.load_ventas(self))
 
     def action_btn_eliminar(self):
         """Accion a realizar al presionar el boton eliminar"""
-        pass
+        index = self.ui.tableView_ventas.currentIndex()
+        if index.row() == -1:  # No se ha seleccionado venta
+            msgBox = QtGui.QMessageBox()
+            msgBox.setIcon(QtGui.QMessageBox.Critical)
+            msgBox.setWindowTitle("Error")
+            msgBox.setText("Debe seleccionar un venta.")
+            msgBox.exec_()
+            return False
+        else:
+            msgBox = QtGui.QMessageBox()
+            msgBox.setIcon(QtGui.QMessageBox.Warning)
+            msgBox.setStandardButtons(
+                QtGui.QMessageBox.Ok | QtGui.QMessageBox.Cancel)
+            msgBox.setWindowTitle(u"Advertencia")
+            msgBox.setText(
+                u"¿Esta seguro de querer eliminar la venta seleccionada?")
+            press = msgBox.exec_()
+            if press == QtGui.QMessageBox.Ok:
+                model = self.ui.tableView_ventas.model()
+                id_venta = model.index(
+                    index.row(), 0, QtCore.QModelIndex()).data()
+                id_pedido = controller_venta.getIdPedido(id_venta)
+                mensaje = controller_venta.delete_venta(id_venta, id_pedido)
+                if mensaje == "Error":
+                    msgBox = QtGui.QMessageBox()
+                    msgBox.setIcon(QtGui.QMessageBox.Critical)
+                    msgBox.setWindowTitle("Error")
+                    msgBox.setText("Esta venta no puede ser eliminada por tener productos asociados.")
+                    msgBox.exec_()
+                else:
+                    self.set_source_model(self.load_ventas(self))
+            else:
+                return False
 
     def load_ventas(self, parent):
         """


### PR DESCRIPTION
En la sección de administración de ventas se habilita el botón para **eliminar una venta**.
Las ventas a eliminar solo seran las que **no** posean productos asignados, osea, los que no generen ingreso al local.
Si el usuario presiona el botón sin seleccionar un venta se le advierte del error. Además si selecciona una venta que no se puede eliminar se le muestra un mensaje de error.
